### PR TITLE
Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.dockerignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:20.04
+
+ENV TZ="America/New_York"
+RUN apt-get update && \
+    apt-get install -yq tzdata && \
+    ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    apt install -y build-essential cmake zlib1g-dev git libeigen3-dev
+
+WORKDIR /build
+
+# Build and install libcifpp
+# https://github.com/PDB-REDO/libcifpp
+RUN cd /build && \
+    git clone https://github.com/PDB-REDO/libcifpp.git --recurse-submodules && \
+    cd libcifpp && \
+    cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/root/.local -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build && \
+    cmake --install build && \
+    echo "libcifpp installed"
+
+# Build and install libmcfp
+# https://github.com/mhekkel/libmcfp
+RUN cd /build && \
+    git clone https://github.com/mhekkel/libmcfp.git && \
+    cd libmcfp && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    cmake --build . && \
+    cmake --install . && \
+    echo "libmcfp installed"
+
+# Build and install dssp
+COPY . /src
+RUN cd /src && \
+    mkdir build && \
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/root/.local/lib/cmake/cifpp/ && \
+    cmake --build build && \
+    cmake --install build && \
+    echo "dssp installed" && \
+    rm -rf /src /build
+
+WORKDIR /data
+ENTRYPOINT ["mkdssp"]

--- a/README.md
+++ b/README.md
@@ -46,3 +46,25 @@ Usage
 -----
 
 See [manual page](doc/mkdssp.md) for more info. Or even better, see the [DSSP website](https://pdb-redo.eu/dssp).
+
+Docker
+------
+
+Build the image yourself: 
+
+```bash
+git clone https://github.com/PDB-REDO/dssp.git
+docker build -t dssp .
+```
+
+Or pull from Docker Hub:
+
+```bash
+docker pull stephenturner/dssp && docker tag stephenturner/dssp dssp
+```
+
+Usage:
+
+```bash
+docker run --rm dssp
+```


### PR DESCRIPTION
Adds a Dockerfile, docker build and usage instructions.

I had difficulty compiling this and its dependencies on a Debian 10 system (old CMake, gcc, etc).

Build the image yourself: 

```bash
docker build -t dssp .
```

Or pull from Docker Hub:

```bash
docker pull stephenturner/dssp && docker tag stephenturner/dssp dssp
```

Usage:

```bash
docker run --rm dssp
```

```
Usage: mkdssp [options] input-file [output-file]
  --output-format arg        Output format, can be either 'dssp' for classic 
                             DSSP or 'mmcif' for annotated mmCIF. The default 
                             is chosen based on the extension of the output 
                             file, if any.
  --min-pp-stretch arg (=3)  Minimal number of residues having PSI/PHI in range 
                             for a PP helix, default is 3
  --write-other              If set, write the type OTHER for loops, default is 
                             to leave this out
  --no-dssp-categories       If set, will suppress output of new DSSP output in 
                             mmCIF format
  --calculate-accessibility  Default is to not calculate the surface 
                             accessibility when the output format is mmCIF
  --mmcif-dictionary arg     Path to the mmcif_pdbx.dic file to use instead of 
                             default
  -h [ --help ]              Display help message
  --version                  Print version
  -v [ --verbose ]           verbose output
  --quiet                    Reduce verbose output to a minimum
```