### PR TITLE
add libpcre2 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -yq tzdata && \
     ln -fs /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
-    apt install -y build-essential cmake zlib1g-dev git libeigen3-dev
+    apt install -y build-essential cmake zlib1g-dev git libeigen3-dev libpcre2-dev
 
 WORKDIR /build
 


### PR DESCRIPTION
Docker build fails at the moment, as c47466dad68673dd6b7a0024fbb1a8d925a32ad9 introduced a new dependency on libpcre2 with the version bump of cifpp to 9. Installing `libpcre2-dev` fixes the build.